### PR TITLE
Fix tvdb package requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tqdm
 retry
-pytvdbapi
+tvdb_api
 PlexAPI
 IMDbPY


### PR DESCRIPTION
The TVDB library was changed with https://github.com/AustinHasten/PlexHolidays/commit/c9703acad34bc7203ac60bcc485d1e37510eeb96, but the requirements.txt file was not.